### PR TITLE
GitHub requires auth via headers now and not query string. See https:…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,11 +10,11 @@ export default function ({
 } = {}) {
   const request = page => fetch.get(`https://api.github.com/repos/${owner}/${repo}/commits`, {
     params: {
-      access_token: token,
       sha,
       per_page: 100,
       page
-    }
+    },
+    headers: {Authorization: `token ${token}`},
   }).then(res => {
     const {headers: {link}, data} = res
     if (!link || page !== 1) {


### PR DESCRIPTION
…//developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/